### PR TITLE
Always close response body in the HasGravatar function

### DIFF
--- a/verifier/gravatar.go
+++ b/verifier/gravatar.go
@@ -11,5 +11,5 @@ func HasGravatar(a *Address) bool {
 	}
 
 	defer resp.Body.Close()
-	return resp.StatusCode != http.StatusOK
+	return resp.StatusCode == http.StatusOK
 }

--- a/verifier/gravatar.go
+++ b/verifier/gravatar.go
@@ -6,9 +6,10 @@ import "net/http"
 // associated with a gravatar account
 func HasGravatar(a *Address) bool {
 	resp, err := http.Head("https://en.gravatar.com/" + a.MD5() + ".json")
-	if err != nil || resp.StatusCode != 200 {
+	if err != nil {
 		return false
 	}
+
 	defer resp.Body.Close()
-	return true
+	return resp.StatusCode != http.StatusOK
 }


### PR DESCRIPTION
Currently the request body isn't being closed if the response is different of 200.
This PR fix it and improve the code.