### PR TITLE
Set HTTP client timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,4 +27,7 @@ var (
 
 	// Env defines the environment where the service is being ran
 	Env = getEnv("ENVIRONMENT", "development")
+
+	// HTTPClientTimeout defines the HTTP client timeout used in requests
+	HTTPClientTimeout, _ = strconv.ParseUint(getEnv("HTTP_CLIENT_TIMEOUT", "5"), 10, 8)
 )

--- a/main.go
+++ b/main.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/sdwolfe32/trumail/api"
@@ -9,6 +11,10 @@ import (
 )
 
 func main() {
+	http.DefaultClient = &http.Client{
+		Timeout: time.Duration(config.HTTPClientTimeout) * time.Second,
+	}
+
 	logger := logrus.New() // New Logger
 
 	if strings.Contains(config.Env, "prod") {


### PR DESCRIPTION
By default, the Go HTTP `DefaultClient` does not have timeout, if any request made in trumail hang, the trumail API will hang too.

This PR adds a new environment variable, `HTTP_CLIENT_TIMEOUT`, to set the timeout in seconds, if it is not set it will be 5 seconds.